### PR TITLE
cleanup and bug fixing

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ In order to customize your cli command name, assign your node project the same n
 Add the filepath to the executable to the PATH env variable of your system, than start a new terminal and input the name of the executable (without extension) followed by commands and optionally parameters for it to run.
  Example with param full name version and full name flag:
 
- `$ app greet person Mary --nighttime`
+ `$ app greet --person Mary --nighttime`
 
  Example with param short version and short name flag:
  

--- a/tests/ParamExtractor.test.ts
+++ b/tests/ParamExtractor.test.ts
@@ -7,24 +7,26 @@ const command = new Command(
     [
         new Param('par', 'p', PropType.Integer, PropConstraint.Required, 'par description'),
         new Param('rap', 'r', PropType.String, PropConstraint.None, 'par description'),
+        new Param('camelCase', 'c', PropType.Float, PropConstraint.None, 'par description'),
         new Flag('flag', 'f', 'flag description'),
-        new Flag('nflag', 'n', 'nflag description')
+        new Flag('nflag', 'n', 'nflag description'),
+        new Flag('camelCaseFlag', 'g', 'gflag description'),
     ],
     ({ params }) => { params; },
     'a test cmd'
 );
 const target = new ParamExtractor();
 
-describe('ParamExtractor', () => {
-    test('should return an error if an invalid parameter is passed after all required params are given', () => {
-        const input = 'par 2 non_exisiting'.split(' ');
-
-        expect(target.parseInput(input, command)).toStrictEqual(new ParamError('Invalid parameter non_exisiting'));
-    });
-
+describe('ParamExtractor', () => {    
     describe('Param', () => {
-        test('should return params with correct type for full name', () => {
-            const input = 'par 2'.split(' ');
+        test('should return an error if an invalid parameter is passed after all required params are given', () => {
+            const input = '-p 2 non_exisiting'.split(' ');
+    
+            expect(target.parseInput(input, command)).toStrictEqual(new ParamError('Invalid parameter non_exisiting'));
+        });
+
+        test('should not return params with correct type for full name', () => {
+            const input = '--par 2'.split(' ');
 
             expect(target.parseInput(input, command)).toHaveProperty('par', 2);
         });
@@ -42,19 +44,23 @@ describe('ParamExtractor', () => {
         });
 
         test('Params should be case-insensitive', () => {
-            const input = 'PAR 2'.split(' ');
+            const input = '-P 2 --camelcase 1.0'.split(' ');
+            const input1 = '--PAR 2 --CAMELCASE 1.0'.split(' ');
 
             expect(target.parseInput(input, command)).toHaveProperty('par', 2);
+            expect(target.parseInput(input, command)).toHaveProperty('camelCase', 1.0);
+            expect(target.parseInput(input1, command)).toHaveProperty('par', 2);
+            expect(target.parseInput(input1, command)).toHaveProperty('camelCase', 1.0);
         });
 
         test('Params arguments should be case-sensitive', () => {
-            const input = 'par 2 -r AbCdEf'.split(' ');
+            const input = '-p 2 -r AbCdEf'.split(' ');
 
             expect(target.parseInput(input, command)).toHaveProperty('rap', 'AbCdEf');
         });
 
         test('Params arguments match expected type', () => {
-            const input = 'par AbCdEf'.split(' ');
+            const input = '-p AbCdEf'.split(' ');
 
             expect(target.parseInput(input, command)).toStrictEqual(new ParamError('Invalid argument type for param: par, Integer expected'));
         });
@@ -84,8 +90,8 @@ describe('ParamExtractor', () => {
         });
 
         test('Params duplication should return an error', () => {
-            const input = 'par 3 par 2'.split(' ');
-            const input1 = 'par 2 par 3'.split(' ');
+            const input = '-p 3 --par 2'.split(' ');
+            const input1 = '-p 2 -p 3'.split(' ');
 
             expect(target.parseInput(input, command)).toStrictEqual(new ParamError('Param: par already existing'));
             expect(target.parseInput(input1, command)).toStrictEqual(new ParamError('Param: par already existing'));
@@ -94,34 +100,38 @@ describe('ParamExtractor', () => {
 
     describe('Flag', () => {
         test('should return flags with a boolean value (false if not passed, true otherwise)', () => {
-            const input = '--flag -p 2'.split(' ');
+            const input = '-p 2 --flag'.split(' ');
+            const input1 = '-p 2'.split(' ');
 
             expect(target.parseInput(input, command)).toHaveProperty('flag', true);
+            expect(target.parseInput(input1, command)).toHaveProperty('flag', false);
         });
 
         test('Flags should always be optional', () => {
             const input = '-p 2'.split(' ');
 
-            expect(target.parseInput(input, command)).toStrictEqual({ flag: false, nflag: false, par: 2 });
+            expect(target.parseInput(input, command)).toStrictEqual({ camelCaseFlag: false, flag: false, nflag: false, par: 2 });
         });
 
         test('Flags should be chainable in one single flag', () => {
             const input = '-p 1 -fn'.split(' ');
 
-            expect(target.parseInput(input, command)).toStrictEqual({ flag: true, nflag: true, par: 1 });
+            expect(target.parseInput(input, command)).toStrictEqual({ camelCaseFlag: false, flag: true, nflag: true, par: 1 });
         });
 
         test('Flags should be case-insensitive', () => {
-            const input = 'par 2 --FLAG'.split(' ');
+            const input = '-p 2 --FLAG --CAMELCASEFLAG'.split(' ');
 
             expect(target.parseInput(input, command)).toHaveProperty('flag', true);
+            expect(target.parseInput(input, command)).toHaveProperty('camelCaseFlag', true);
         });
 
-        test('Flags order over params should not change result', () => {
-            const input = '--flag par 2 '.split(' ');
+        test('Flags order over non required params should not change result', () => {
+            const input = '-p 2 --flag -r abc'.split(' ');
 
             expect(target.parseInput(input, command)).toHaveProperty('flag', true);
             expect(target.parseInput(input, command)).toHaveProperty('par', 2);
+            expect(target.parseInput(input, command)).toHaveProperty('rap', 'abc');
         });
     });
 });


### PR DESCRIPTION
- camelcase name for params and flags are handled
- both params and flags require 1 dash for short name and 2 for full name. required params can still be passed positionally